### PR TITLE
Execute manip plan

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ add_service_files(
   RobotSetMode.srv
   RobotGetVizInfo.srv
   RobotGetTarget.srv
+  RobotGetNamedTargets.srv
   RobotGetConfig.srv
   RobotNavigationGoal.srv
   RobotGripperControlPosition.srv

--- a/include/temoto_robot_manager/robot.h
+++ b/include/temoto_robot_manager/robot.h
@@ -51,14 +51,14 @@ public:
   void recover(const std::string& parent_query_id);
   void addPlanningGroup(const std::string& planning_group_name);
   void removePlanningGroup(const std::string& planning_group_name);
-  void planManipulationPath(std::string& planning_group_name, const geometry_msgs::PoseStamped& target_pose);
-  void planManipulationPath(std::string& planning_group_name, const std::string& named_target);  
+  void planManipulationPath(const std::string& planning_group_name, const geometry_msgs::PoseStamped& target_pose);
+  void planManipulationPath(const std::string& planning_group_name, const std::string& named_target);  
 
   void executeManipulationPath();
   
   geometry_msgs::Pose getManipulationTarget();
 
-  std::vector<std::string> getNamedTargetPoses(std::string& planning_group_name);
+  std::vector<std::string> getNamedTargetPoses(const std::string& planning_group_name);
   
   void goalNavigation(const std::string& reference_frame, const geometry_msgs::PoseStamped& target_pose);
   void controlGripper(const std::string& robot_name, const float position);

--- a/include/temoto_robot_manager/robot.h
+++ b/include/temoto_robot_manager/robot.h
@@ -57,6 +57,9 @@ public:
   void executeManipulationPath();
   
   geometry_msgs::Pose getManipulationTarget();
+
+  std::vector<std::string> getNamedTargetPoses(std::string& planning_group_name);
+  
   void goalNavigation(const std::string& reference_frame, const geometry_msgs::PoseStamped& target_pose);
   void controlGripper(const std::string& robot_name, const float position);
   

--- a/include/temoto_robot_manager/robot_manager.h
+++ b/include/temoto_robot_manager/robot_manager.h
@@ -87,6 +87,8 @@ private:
 
   bool getManipulationTargetCb(RobotGetTarget::Request& req, RobotGetTarget::Response& res);
 
+  bool getManipulationNamedTargetsCb(RobotGetNamedTargets::Request& req, RobotGetNamedTargets::Response& res);
+
   bool goalNavigationCb(RobotNavigationGoal::Request& req, RobotNavigationGoal::Response& res);
 
   bool gripperControlPositionCb(RobotGripperControlPosition::Request& req, RobotGripperControlPosition::Response& res);
@@ -132,6 +134,7 @@ private:
   ros::ServiceServer server_get_viz_cfg_;
   ros::ServiceServer server_set_manipulation_target_;
   ros::ServiceServer server_get_manipulation_target_;
+  ros::ServiceServer server_get_manipulation_named_targets_;
   ros::ServiceServer server_set_mode_;
   ros::ServiceServer server_navigation_goal_;
   ros::ServiceServer server_gripper_control_position_;
@@ -142,6 +145,7 @@ private:
   ros::ServiceClient client_get_viz_cfg_;
   ros::ServiceClient client_set_manipulation_target_;
   ros::ServiceClient client_get_manipulation_target_;
+  ros::ServiceClient client_get_manipulation_named_targets_;
   ros::ServiceClient client_set_mode_;
   ros::ServiceClient client_navigation_goal_;
   ros::ServiceClient client_gripper_control_position_;

--- a/include/temoto_robot_manager/robot_manager_interface.h
+++ b/include/temoto_robot_manager/robot_manager_interface.h
@@ -57,6 +57,8 @@ public:
         nh_.serviceClient<RobotSetTarget>(srv_name::SERVER_SET_MANIPULATION_TARGET);
       client_get_manipulation_target_ =
         nh_.serviceClient<RobotGetTarget>(srv_name::SERVER_GET_MANIPULATION_TARGET);
+      client_get_manipulation_named_targets_ =
+        nh_.serviceClient<RobotGetNamedTargets>(srv_name::SERVER_GET_MANIPULATION_NAMED_TARGETS);
       client_navigation_goal_ =
         nh_.serviceClient<RobotNavigationGoal>(srv_name::SERVER_NAVIGATION_GOAL);
       client_gripper_control_position_ =
@@ -247,6 +249,24 @@ public:
     return pose;
   }
 
+ std::vector<std::string> getNamedTargets(const std::string& robot_name, const std::string& planning_group)
+ {
+    std::vector<std::string> named_target_poses;
+    temoto_robot_manager::RobotGetNamedTargets msg; 
+    msg.request.robot_name = robot_name;
+    msg.request.planning_group = planning_group;
+    if (!client_get_manipulation_named_targets_.call(msg))
+    {
+      throw TEMOTO_ERRSTACK("Unable to reach robot_manager");
+    }
+    if (!msg.response.success)
+    {
+      throw TEMOTO_ERRSTACK("Unsuccessful attempt to invoke 'getEndEffPose'");
+    }
+    named_target_poses = msg.response.named_target_poses;
+    return named_target_poses;
+  }
+
   void navigationGoal(const std::string& robot_name
   , const std::string& reference_frame
   , const geometry_msgs::PoseStamped& pose)
@@ -354,6 +374,7 @@ private:
   ros::ServiceClient client_viz_info_;
   ros::ServiceClient client_set_manipulation_target_;  
   ros::ServiceClient client_get_manipulation_target_;
+  ros::ServiceClient client_get_manipulation_named_targets_;
   ros::ServiceClient client_navigation_goal_;
   ros::ServiceClient client_gripper_control_position_;
   ros::ServiceClient client_get_robot_config_; 

--- a/include/temoto_robot_manager/robot_manager_services.h
+++ b/include/temoto_robot_manager/robot_manager_services.h
@@ -24,6 +24,7 @@
 #include "temoto_robot_manager/RobotSetMode.h"
 #include "temoto_robot_manager/RobotGetVizInfo.h"
 #include "temoto_robot_manager/RobotGetTarget.h"
+#include "temoto_robot_manager/RobotGetNamedTargets.h"
 #include "temoto_robot_manager/RobotNavigationGoal.h"
 #include "temoto_robot_manager/RobotGripperControlPosition.h"
 #include "temoto_robot_manager/RobotGetConfig.h"
@@ -44,6 +45,7 @@ const std::string SERVER_GET_VIZ_INFO = "get_visualization_info";
 const std::string SERVER_GET_CONFIG = "get_config";
 const std::string SERVER_SET_MANIPULATION_TARGET = "set_manipulation_target";
 const std::string SERVER_GET_MANIPULATION_TARGET = "get_manipulation_target";
+const std::string SERVER_GET_MANIPULATION_NAMED_TARGETS = "get_manipulation_named_targets";
 const std::string SERVER_NAVIGATION_GOAL = "navigation_goal";
 const std::string SERVER_SET_MODE = "set_mode";
 const std::string SERVER_GRIPPER_CONTROL_POSITION = "gripper_control_position";

--- a/src/robot.cpp
+++ b/src/robot.cpp
@@ -608,10 +608,18 @@ void Robot::executeManipulationPath()
       planning_groups_.find(planning_group_name);  ///< Will throw if group does not exist
   if (group_it != planning_groups_.end())
   {
-    bool success;
+    bool success = false;
     group_it->second->setStartStateToCurrentState();
     group_it->second->setRandomTarget();
-    success = static_cast<bool>(group_it->second->execute(last_plan));
+    //success = static_cast<bool>(group_it->second->execute(last_plan));
+    size_t i=0;
+    while (!success && i<3) 
+    {
+      TEMOTO_INFO_STREAM("Attempt = " << i+1);
+      ++i;
+      success = static_cast<bool>(group_it->second->execute(last_plan));
+    }
+
     TEMOTO_DEBUG("Execution %s",  success ? "SUCCESSFUL" : "FAILED");
     if(!success)
     {

--- a/src/robot.cpp
+++ b/src/robot.cpp
@@ -542,7 +542,7 @@ void Robot::planManipulationPath(const std::string& planning_group_name, const g
 
   FeatureManipulation& ftr = config_->getFeatureManipulation();
 
-  std::string planning_group = (planning_group_name == "") ? ftr.getActivePlanningGroup() : planning_group_name;
+  std::string planning_group = (planning_group_name.empty()) ? ftr.getActivePlanningGroup() : planning_group_name;
   auto group_it = planning_groups_.find(planning_group);
   if (group_it == planning_groups_.end())
   {
@@ -571,7 +571,7 @@ void Robot::planManipulationPath(const std::string& planning_group_name, const s
 
   FeatureManipulation& ftr = config_->getFeatureManipulation();
 
-  std::string planning_group = (planning_group_name == "") ? ftr.getActivePlanningGroup() : planning_group_name;
+  std::string planning_group = (planning_group_name.empty()) ? ftr.getActivePlanningGroup() : planning_group_name;
   auto group_it = planning_groups_.find(planning_group);
   if (group_it == planning_groups_.end())
   {

--- a/srv/RobotGetNamedTargets.srv
+++ b/srv/RobotGetNamedTargets.srv
@@ -1,0 +1,7 @@
+string robot_name
+string planning_group
+
+---
+
+string[] named_target_poses
+bool success


### PR DESCRIPTION
- Added a server to get the namedTargetPoses of the planning groups. It helps users to command the robot to predefined poses using the robot manager interface.
- Added 3 attempts to execute last plan, and throw an error in case it fails. 
